### PR TITLE
Add and implement new front end money input parser

### DIFF
--- a/app/components/balances/BalanceCorrection.tsx
+++ b/app/components/balances/BalanceCorrection.tsx
@@ -111,33 +111,37 @@ export default function BalanceCorrection(
             <td></td>
 
             <td>
-                <input 
-                    className="m-2 rounded-lg p-2 text-l"
-                    value={ balanceChange.toFixed(2) }
-                    onChange={ (e) => {
-                        const num = formatVal(e.currentTarget.value);
-                        if (isNaN(num)) { return };
-                
-                        const diff = currentBalance + num;
-                        setBalanceChange(num);
-                        setNewBalance(diff);
-                    } }
-                />
+                <span>$
+                    <input
+                        className="m-2 rounded-lg p-2 text-l"
+                        value={ balanceChange.toFixed(2) }
+                        onChange={ (e) => {
+                            const num = formatVal(e.currentTarget.value);
+                            if (isNaN(num)) { return };
+                            
+                            const diff = currentBalance + num;
+                            setBalanceChange(num);
+                            setNewBalance(diff);
+                        } }
+                    />
+                </span>
             </td>
 
             <td>
-                <input
-                    className="m-2 rounded-lg p-2 text-l"
-                    value={ newBalance.toFixed(2) }
-                    onChange={ e => {
-                        const num = formatVal(e.currentTarget.value);
-                        if (isNaN(num)) { return };
-                
-                        const diff = num - currentBalance;
-                        setBalanceChange(diff);
-                        setNewBalance(num);
-                    } }
-                />
+                <span>$
+                    <input
+                        className="m-2 rounded-lg p-2 text-l"
+                        value={ newBalance.toFixed(2) }
+                        onChange={ e => {
+                            const num = formatVal(e.currentTarget.value);
+                            if (isNaN(num)) { return };
+                    
+                            const diff = num - currentBalance;
+                            setBalanceChange(diff);
+                            setNewBalance(num);
+                        } }
+                    />
+                </span>
             </td>
 
             <td>

--- a/app/components/balances/BalanceCorrection.tsx
+++ b/app/components/balances/BalanceCorrection.tsx
@@ -5,6 +5,7 @@ import { patchHistory } from "../../lib/balancesFunctions";
 import { balanceHistoryDictType, stateType, voidFunc } from "../../lib/commonTypes";
 import { usePathname, useRouter } from "next/navigation";
 import EntryRow from "./EntryRow";
+import { formatVal } from "../../lib/commonFunctions";
 
 type TransactionModalPropTypes = {
     id: string,
@@ -104,44 +105,6 @@ export default function BalanceCorrection(
     const [newBalance, setNewBalance] = useState(0);
     const [description, setDescription] = useState('');
 
-    const balanceChangeCalc = (val: string) => {
-        if (!val) {
-            setBalanceChange(0);
-            setNewBalance(currentBalance);
-            setMessage('');
-            return;
-        };
-
-        let num = Number(val)
-        if (num) {
-            num = Math.round(num * 100) / 100
-            const diff = Math.round((currentBalance + num) * 100) / 100
-            setBalanceChange(num);
-            setNewBalance(diff);
-            setMessage('');
-        
-        } else { setMessage('Only numbers are allowed in balance boxes.') };
-    };
-
-    const newBalanceCalc = (val: string) => {
-        if (!val) {
-            setBalanceChange(currentBalance * -1);
-            setNewBalance(0);
-            setMessage('');
-            return;
-        };
-        
-        let num = Number(val)
-        if (num) {
-            num = Math.round(num * 100) / 100
-            const diff = Math.round((num - currentBalance) * 100) / 100
-            setBalanceChange(diff);
-            setNewBalance(num);
-            setMessage('');
-        
-        } else { setMessage('Only numbers are allowed in balance boxes.') };
-    };
-
     return (<>
         <tr className="bg-gray-100">
             <td></td>
@@ -150,18 +113,33 @@ export default function BalanceCorrection(
             <td>
                 <input 
                     className="m-2 rounded-lg p-2 text-l"
-                    value={balanceChange} 
-                    onChange={ (e) => balanceChangeCalc(e.currentTarget.value) }
+                    value={ balanceChange.toFixed(2) }
+                    onChange={ (e) => {
+                        const num = formatVal(e.currentTarget.value);
+                        if (isNaN(num)) { return };
+                
+                        const diff = currentBalance + num;
+                        setBalanceChange(num);
+                        setNewBalance(diff);
+                    } }
                 />
             </td>
 
             <td>
                 <input
                     className="m-2 rounded-lg p-2 text-l"
-                    value={newBalance}
-                    onChange={ (e) => newBalanceCalc(e.currentTarget.value) }
+                    value={ newBalance.toFixed(2) }
+                    onChange={ e => {
+                        const num = formatVal(e.currentTarget.value);
+                        if (isNaN(num)) { return };
+                
+                        const diff = num - currentBalance;
+                        setBalanceChange(diff);
+                        setNewBalance(num);
+                    } }
                 />
             </td>
+
             <td>
                 <input 
                     className="m-2 rounded-lg p-2 text-l"

--- a/app/components/balances/BalanceCorrection.tsx
+++ b/app/components/balances/BalanceCorrection.tsx
@@ -115,6 +115,12 @@ export default function BalanceCorrection(
                     <input
                         className="m-2 rounded-lg p-2 text-l"
                         value={ balanceChange.toFixed(2) }
+                        onKeyDown={ e => {
+                            if (e.key !== '-') { return };
+                            const num = Number(e.currentTarget.value) * -1;
+                            setBalanceChange(num);
+                            setNewBalance(currentBalance + num);
+                        } }
                         onChange={ (e) => {
                             const num = formatVal(e.currentTarget.value);
                             if (isNaN(num)) { return };
@@ -132,6 +138,12 @@ export default function BalanceCorrection(
                     <input
                         className="m-2 rounded-lg p-2 text-l"
                         value={ newBalance.toFixed(2) }
+                        onKeyDown={ e => {
+                            if (e.key !== '-') { return };
+                            const num = Number(e.currentTarget.value) * -1;
+                            setBalanceChange(num - currentBalance);
+                            setNewBalance(num);
+                        } }
                         onChange={ e => {
                             const num = formatVal(e.currentTarget.value);
                             if (isNaN(num)) { return };

--- a/app/components/balances/BalanceCorrection.tsx
+++ b/app/components/balances/BalanceCorrection.tsx
@@ -125,9 +125,8 @@ export default function BalanceCorrection(
                             const num = formatVal(e.currentTarget.value);
                             if (isNaN(num)) { return };
                             
-                            const diff = currentBalance + num;
                             setBalanceChange(num);
-                            setNewBalance(diff);
+                            setNewBalance(currentBalance + num);
                         } }
                     />
                 </span>
@@ -148,8 +147,7 @@ export default function BalanceCorrection(
                             const num = formatVal(e.currentTarget.value);
                             if (isNaN(num)) { return };
                     
-                            const diff = num - currentBalance;
-                            setBalanceChange(diff);
+                            setBalanceChange(num - currentBalance);
                             setNewBalance(num);
                         } }
                     />

--- a/app/components/payments/PaymentRow.tsx
+++ b/app/components/payments/PaymentRow.tsx
@@ -34,26 +34,28 @@ export default function PaymentRow({ id, info, paymentsInfoState, setMessage, re
             <td className="pl-4 py-2">{info.name}</td>
             <td className="pl-4 py-2">{formatter.format(info.balance)}</td>
             <td className="w-full h-full">
-                <input
-                    className="rounded-lg px-4 py-1"
-                    value={ payment.toFixed(2) }
-                    onChange={ e => {
-                        const num = formatVal(e.currentTarget.value);
-                        if (isNaN(num)) { return };
-                
-                        setPayment(num);
-                        setNewBalance(info.balance - num);
-                    } }
-                    onBlur={ () => {
-                        setPaymentsInfo({
-                            ...paymentsInfo,
-                            [id]: {
-                                ...info,
-                                payment
-                            }
-                        });
-                    } }
-                />
+                <span>$
+                    <input
+                        className="rounded-lg px-4 py-1 ml-2"
+                        value={ payment.toFixed(2) }
+                        onChange={ e => {
+                            const num = formatVal(e.currentTarget.value);
+                            if (isNaN(num)) { return };
+                            
+                            setPayment(num);
+                            setNewBalance(info.balance - num);
+                        } }
+                        onBlur={ () => {
+                            setPaymentsInfo({
+                                ...paymentsInfo,
+                                [id]: {
+                                    ...info,
+                                    payment
+                                }
+                            });
+                        } }
+                    />
+                </span>
             </td>
             <td className="pl-4 py-2">{formatter.format(newBalance)}</td>
         </tr>

--- a/app/components/payments/PaymentRow.tsx
+++ b/app/components/payments/PaymentRow.tsx
@@ -38,6 +38,12 @@ export default function PaymentRow({ id, info, paymentsInfoState, setMessage, re
                     <input
                         className="rounded-lg px-4 py-1 ml-2"
                         value={ payment.toFixed(2) }
+                        onKeyDown={ e => {
+                            if (e.key !== '-') { return };
+                            const num = Number(e.currentTarget.value) * -1;
+                            setPayment(num);
+                            setNewBalance(info.balance - num);
+                        } }
                         onChange={ e => {
                             const num = formatVal(e.currentTarget.value);
                             if (isNaN(num)) { return };

--- a/app/components/payments/PaymentRow.tsx
+++ b/app/components/payments/PaymentRow.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { stateType, voidFunc } from "../../lib/commonTypes";
 import { paymentsInfoType } from "../../payments/page";
+import { formatVal } from "../../lib/commonFunctions";
 
 type PaymentRowPropsType = {
     id: string,
@@ -21,23 +22,6 @@ export default function PaymentRow({ id, info, paymentsInfoState, setMessage, re
     
     useEffect(() => { setPayment(0) }, [reset])
     
-    const attmeptSetPayment = (val: string) => {
-        if (!val) {
-            setPayment(0);
-            setNewBalance(info.balance);
-            setMessage('');
-            return;
-        };
-        
-        let num = Number(val);
-        if (num) {
-            num = Math.round(num * 100) / 100;
-            setPayment(num);
-            setNewBalance(info.balance - num);
-            setMessage('');
-        } else { setMessage('Only numbers are allowed in balance boxes.') };
-    };
-
     const formatter = new Intl.NumberFormat('en-US', {
         style: 'currency',
         currency: 'USD',
@@ -52,8 +36,14 @@ export default function PaymentRow({ id, info, paymentsInfoState, setMessage, re
             <td className="w-full h-full">
                 <input
                     className="rounded-lg px-4 py-1"
-                    value={payment}
-                    onChange={ e => attmeptSetPayment(e.currentTarget.value) }
+                    value={ payment.toFixed(2) }
+                    onChange={ e => {
+                        const num = formatVal(e.currentTarget.value);
+                        if (isNaN(num)) { return };
+                
+                        setPayment(num);
+                        setNewBalance(info.balance - num);
+                    } }
                     onBlur={ () => {
                         setPaymentsInfo({
                             ...paymentsInfo,

--- a/app/lib/commonFunctions.ts
+++ b/app/lib/commonFunctions.ts
@@ -1,0 +1,31 @@
+export const formatVal = (val: string) => {
+    if (isNaN(Number(val))) {
+        return NaN;
+    };
+
+    let vals = val.toString().split('.');
+
+    // decimal was deleted
+    if (vals.length == 1) {
+        let n = vals[0]
+        let whole = n.slice(0, n.length - 2);
+        let decimal = n.slice(n.length - 2, n.length);
+        return Number(whole + '.' + decimal);
+    };
+
+    let whole = vals[0], decimal = vals[1];
+
+    // decimal place was removed
+    if (decimal.length == 1) {
+        decimal = whole[whole.length - 1] + decimal[0];
+        whole = whole.slice(0, whole.length - 1);
+    }
+
+    // decimal place was added
+    else if (decimal.length == 3) {
+        whole = whole + decimal[0];
+        decimal = decimal.slice(1, decimal.length);
+    };
+
+    return Number(whole + '.' + decimal);
+};

--- a/app/lib/commonFunctions.ts
+++ b/app/lib/commonFunctions.ts
@@ -1,7 +1,6 @@
 export const formatVal = (val: string) => {
-    if (isNaN(Number(val))) {
-        return NaN;
-    };
+    if (val == '') { return 0 };
+    if (isNaN(Number(val))) { return NaN };
 
     let vals = val.toString().split('.');
 


### PR DESCRIPTION
## tl;dr
- Resolves #3
- Enables more intuitive dollar amount entry in form inputs found in endpoints like /balances and /payments
- Handles decimal place changes and sign changes

---

### Before, 
dollar amounts with a decimal place needed to be entered the following way:
```
0 --> 1 --> 12 --> 123 --> 12.3
```
where the decimal place had to placed after a portion or the entire number was input.

### Now,
dollar amounts and dollar amount changes are handled in a more intuitive way. Like so:
```
0.00 --> 0.01 --> 0.12 --> 1.23 --> 12.34 --> ...
```
where the cursor is placed by default at the beginning of the number, and any new input 'pushes' the previous amount over by one decimal place. 

Middle numbers also properly displace already existing numbers, like so:
```
123.45 --> 1263.45
```
or, if entering a new decimal place:
```
123.45 --> 1234.65
```
where upon entering the number '6' in the tenth's place, the number '4' gets pushed to the one's place to make room for the new tenth's place number.

---


### Negative number input is also handled more intuitively.

Now, whenever the negative sign key is detected as an input, the number simply has it's sign switched.
```
123.45 ---> -123.45
```
The placement of the negative sign doesn't make a difference.