### PR TITLE
Sort name lists completely

### DIFF
--- a/app/balances/page.tsx
+++ b/app/balances/page.tsx
@@ -7,7 +7,7 @@ import { usePathname, useRouter } from "next/navigation";
 import Message from "../components/message/Message";
 import HistoryTable from "../components/balances/HistoryTable";
 import Spinner from "../components/spinner/Spinner";
-import { nameSort } from "../lib/commonFunctions";
+import { stringCompare } from "../lib/commonFunctions";
 
 export default function Balances() {
     const pathname = usePathname();
@@ -64,7 +64,7 @@ export default function Balances() {
                 });
 
                 setHistory(historyDraft);
-                setOptions(optionsDraft.sort((a, b) => nameSort(
+                setOptions(optionsDraft.sort((a, b) => stringCompare(
                     a.props['children'], 
                     b.props['children'] 
                 )));

--- a/app/balances/page.tsx
+++ b/app/balances/page.tsx
@@ -7,6 +7,7 @@ import { usePathname, useRouter } from "next/navigation";
 import Message from "../components/message/Message";
 import HistoryTable from "../components/balances/HistoryTable";
 import Spinner from "../components/spinner/Spinner";
+import { nameSort } from "../lib/commonFunctions";
 
 export default function Balances() {
     const pathname = usePathname();
@@ -63,10 +64,10 @@ export default function Balances() {
                 });
 
                 setHistory(historyDraft);
-                setOptions(optionsDraft.sort((a, b) => {
-                    return a.props['children'].charCodeAt(0) - b.props['children'].charCodeAt(0)
-                } ));
-                // setId(ret.data[0]._id);
+                setOptions(optionsDraft.sort((a, b) => nameSort(
+                    a.props['children'], 
+                    b.props['children'] 
+                )));
             };
         });
 

--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -14,6 +14,7 @@ import Bills from "../components/billing/Bills";
 import Selections from "../components/billing/Selections";
 import Spinner from "../components/spinner/Spinner";
 import { backFlushId, wellHeadId } from "../lib/settings";
+import { nameSort } from "../lib/commonFunctions";
 
 export default function Billing() {
     const router = useRouter();
@@ -60,7 +61,7 @@ export default function Billing() {
                     ) {
                         return item;
                     };
-                }).sort((a, b) => a.name.charCodeAt(0) - b.name.charCodeAt(0)));
+                }).sort((a, b) => nameSort(a.name, b.name)));
 
                 setUsers((draft: usersInfoDictType = {}) => {
                     ret.users.map(user => {

--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -14,7 +14,7 @@ import Bills from "../components/billing/Bills";
 import Selections from "../components/billing/Selections";
 import Spinner from "../components/spinner/Spinner";
 import { backFlushId, wellHeadId } from "../lib/settings";
-import { nameSort } from "../lib/commonFunctions";
+import { stringCompare } from "../lib/commonFunctions";
 
 export default function Billing() {
     const router = useRouter();
@@ -61,7 +61,7 @@ export default function Billing() {
                     ) {
                         return item;
                     };
-                }).sort((a, b) => nameSort(a.name, b.name)));
+                }).sort((a, b) => stringCompare(a.name, b.name)));
 
                 setUsers((draft: usersInfoDictType = {}) => {
                     ret.users.map(user => {

--- a/app/lib/commonFunctions.ts
+++ b/app/lib/commonFunctions.ts
@@ -28,3 +28,16 @@ export const formatVal = (val: string) => {
 
     return Number(whole + '.' + decimal);
 };
+
+
+/**
+ * assistive function for sorting words alphatecially
+ * @param left string
+ * @param right string
+ * @returns 0, 1, or -1 based on string comparison
+ */
+export const nameSort = (left: string, right: string) => {
+    if (left < right) { return -1 }
+    else if (left > right) { return 1}
+    else { return 0 };
+};

--- a/app/lib/commonFunctions.ts
+++ b/app/lib/commonFunctions.ts
@@ -1,3 +1,8 @@
+/**
+ * Formats numbers based on the following: 1) may contain any number of leading digits before the decimal 2) may only contain two decimal places (will default to .00)
+ * @param val string
+ * @returns a number in the form of a float
+ */
 export const formatVal = (val: string) => {
     if (val == '') { return 0 };
     if (isNaN(Number(val))) { return NaN };
@@ -14,13 +19,13 @@ export const formatVal = (val: string) => {
 
     let whole = vals[0], decimal = vals[1];
 
-    // decimal place was removed
+    // not enough decimal places
     if (decimal.length == 1) {
         decimal = whole[whole.length - 1] + decimal[0];
         whole = whole.slice(0, whole.length - 1);
     }
 
-    // decimal place was added
+    // too many decimal places
     else if (decimal.length == 3) {
         whole = whole + decimal[0];
         decimal = decimal.slice(1, decimal.length);

--- a/app/lib/commonFunctions.ts
+++ b/app/lib/commonFunctions.ts
@@ -41,7 +41,7 @@ export const formatVal = (val: string) => {
  * @param right string
  * @returns 0, 1, or -1 based on string comparison
  */
-export const nameSort = (left: string, right: string) => {
+export const stringCompare = (left: string, right: string) => {
     if (left < right) { return -1 }
     else if (left > right) { return 1}
     else { return 0 };


### PR DESCRIPTION
### Solves #9 

---

Improves and abstracts the string comparison logic for the two Array.prototype.sort methods in the /billing and /balances endpoints that were used to sort arrays based on name.