### PR TITLE
Bug/data table nav

### DIFF
--- a/app/components/dataEntry/HomesReadingsRow.tsx
+++ b/app/components/dataEntry/HomesReadingsRow.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect } from "react";
 import { dataDictType } from "../../dataEntry/page";
 import { quarterType, stateType, voidFunc, yearType } from "../../lib/commonTypes"
 
@@ -7,6 +7,8 @@ type HomesReadingsRowsType = {
     quarter: quarterType
     state: stateType<dataDictType>
     setMessage: voidFunc<string>
+    setFocus: voidFunc<number>
+    setMaxIdx: voidFunc<number>
 };
 
 export default function HomesReadingsRows(
@@ -14,7 +16,9 @@ export default function HomesReadingsRows(
         year,
         quarter,
         state,
-        setMessage
+        setMessage,
+        setFocus,
+        setMaxIdx
     }: HomesReadingsRowsType
 ) {
     const updateHomesDataUpdate = (
@@ -49,44 +53,7 @@ export default function HomesReadingsRows(
     };
 
     const entries = Object.entries(state.value);
-    const maxIdx = 3 * entries.length;
-    const [focus, setFocus] = useState(0);
-
-    const [shift, setShift] = useState(false);
-    document.onkeyup = (key) => {
-        if (key.key == 'Shift') { setShift(false) };
-    };
-
-    document.onkeydown = (key) => {
-        if (key.key == 'Shift') { setShift(true); return };
-        
-        const activeElement = document.activeElement
-        if (!activeElement) { return };
-
-        // @ts-expect-error
-        const idx = activeElement.tabIndex;
-        if (idx <= 0) { return };
-
-        let newFocus = focus;
-
-        if (key.key == 'Enter' && !shift) {
-            if (focus == maxIdx) { return };
-            newFocus = focus + 3;
-            if (newFocus > maxIdx) {
-                newFocus = newFocus % 3 + 1;
-            };
-
-        } else if (key.key == 'Enter' && shift) {
-            if (focus == 1) { return };
-            newFocus = focus - 3;
-            if (newFocus < 1) {
-                newFocus = newFocus + maxIdx - 1
-            };
-        };
-
-        document.getElementById(`tabIDX=${newFocus}`)?.focus();
-        setFocus(newFocus);
-    };
+    useEffect(() => { setMaxIdx(entries.length * 3) }, []);
 
     return entries.map(([userId, userInfo], idx) => {
         return(

--- a/app/components/dataEntry/HomesReadingsRow.tsx
+++ b/app/components/dataEntry/HomesReadingsRow.tsx
@@ -53,7 +53,8 @@ export default function HomesReadingsRows(
     };
 
     const entries = Object.entries(state.value);
-    useEffect(() => { setMaxIdx(entries.length * 3) }, []);
+    // six is added to this value because there are two more rows, well head and back flush
+    useEffect(() => { setMaxIdx(entries.length * 3 + 6) }, []);
 
     return entries.map(([userId, userInfo], idx) => {
         return(
@@ -69,6 +70,7 @@ export default function HomesReadingsRows(
                 { 
                     [1, 2, 3].map(month => {
                         if (month !== 1 && month !== 2 && month !== 3) { return <></> };
+                        const cellIdx = (idx * 3) + month;
                         return (
                             <td key={month}>
                                 <input
@@ -81,8 +83,8 @@ export default function HomesReadingsRows(
                                         )
                                     }}
                                     value={state.value[userId].data[year][quarter][month]}
-                                    id={ `tabIDX=${(idx * 3) + month}` }
-                                    tabIndex={ (idx * 3) + month }
+                                    id={ `tabIDX=${cellIdx}` }
+                                    tabIndex={cellIdx}
                                     onFocus={ e => setFocus(e.target.tabIndex) }
                                 />
                             </td>

--- a/app/components/dataEntry/OtherReadingsRow.tsx
+++ b/app/components/dataEntry/OtherReadingsRow.tsx
@@ -5,6 +5,8 @@ type OtherReadingsRowType = {
     year: yearType
     states: stateType<waterUsageType | undefined>[]
     setMessage: voidFunc<string>
+    setFocus: voidFunc<number>
+    maxIdx: undefined | number
 };
 
 export default function OtherReadingsRow(
@@ -12,7 +14,9 @@ export default function OtherReadingsRow(
         quarter,
         year, 
         states,
-        setMessage
+        setMessage,
+        setFocus,
+        maxIdx
     }: OtherReadingsRowType
 ) {
     const updateOtherDataUpdate = (input: {
@@ -45,6 +49,7 @@ export default function OtherReadingsRow(
         });
     };
 
+    if (!maxIdx) { return <></> };
     return states.map((state, idx) => {
         const { value, setValue } = state;
         if (!value || !setValue) { return };

--- a/app/components/dataEntry/OtherReadingsRow.tsx
+++ b/app/components/dataEntry/OtherReadingsRow.tsx
@@ -66,6 +66,7 @@ export default function OtherReadingsRow(
                 <td className="text-xl uppercase p-2">{value.name}</td>
                 { [1, 2, 3].map(month => {
                     if (month !== 1 && month !== 2 && month !== 3) { return <></> };
+                    const cellIdx = (maxIdx - 6) + (idx * 3) + month;
                     return(
                         <td key={month}>
                             <input
@@ -77,6 +78,9 @@ export default function OtherReadingsRow(
                                     })
                                 }
                                 value={value.data[year][quarter][month]}
+                                id={ `tabIDX=${cellIdx}` }
+                                tabIndex={cellIdx}
+                                onFocus={ e => setFocus(e.target.tabIndex) }
                             />
                         </td>
                     )

--- a/app/dataEntry/page.tsx
+++ b/app/dataEntry/page.tsx
@@ -156,6 +156,46 @@ export default function DataEntry() {
         setLoading(false);
     };
 
+    const [maxIdx, setMaxIdx] = useState<undefined | number>();
+    const [focus, setFocus] = useState(0);
+    const [shift, setShift] = useState(false);
+
+    document.onkeyup = (key) => {
+        if (key.key == 'Shift') { setShift(false) };
+    };
+
+    document.onkeydown = (key) => {
+        if (!maxIdx) { return };
+        if (key.key == 'Shift') { setShift(true); return };
+        
+        const activeElement = document.activeElement
+        if (!activeElement) { return };
+
+        // @ts-expect-error
+        const idx = activeElement.tabIndex;
+        if (idx <= 0) { return };
+
+        let newFocus = focus;
+
+        if (key.key == 'Enter' && !shift) {
+            if (focus == maxIdx) { return };
+            newFocus = focus + 3;
+            if (newFocus > maxIdx) {
+                newFocus = newFocus % 3 + 1;
+            };
+
+        } else if (key.key == 'Enter' && shift) {
+            if (focus == 1) { return };
+            newFocus = focus - 3;
+            if (newFocus < 1) {
+                newFocus = newFocus + maxIdx - 1
+            };
+        };
+
+        document.getElementById(`tabIDX=${newFocus}`)?.focus();
+        setFocus(newFocus);
+    };
+
     return (<>
         <Message messageState={{ value: message, setValue: setMessage }} />
         { loading ? <Spinner /> : <>
@@ -199,6 +239,8 @@ export default function DataEntry() {
                                             setValue: setHomesDataUpdate 
                                         }}
                                         setMessage={setMessage}
+                                        setFocus={setFocus}
+                                        setMaxIdx={setMaxIdx}
                                     />
                                 </>
                             }
@@ -214,6 +256,8 @@ export default function DataEntry() {
                                     { value: backflushDataUpdate, setValue: setBackflushDataUpdate }
                                 ]}
                                 setMessage={setMessage}
+                                setFocus={setFocus}
+                                maxIdx={maxIdx}
                             />
 
                         </tbody>


### PR DESCRIPTION
### Resolves #22

---

This PR allows the bottom two rows, well head and back flush readings, to be navigated to and from using the shift and enter keys, just like the water user rows in the /dataEntry data table.