### PR TITLE
further specify on what events the main CI should run

### DIFF
--- a/.github/workflows/CI main.yml
+++ b/.github/workflows/CI main.yml
@@ -2,9 +2,10 @@ name: CI main
 
 on:
   push:
-    branches: [ "main" ]
+    branches: "main"
   pull_request:
-    branches: [ "main" ]
+    types: closed
+    branches: "main"
   workflow_dispatch:
 
 env:
@@ -13,6 +14,7 @@ env:
 
 jobs:
   build_and_push:
+    if: github.event_name == 'push' || github.event.pull_request.merged
     name: build and push Docker image to ghcr
     
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Resolves #27

---

This PR will alter the main CI workflow so that it only runs on a push to or successful merge into the main branch.