### PR TITLE
prevent the main CI from running twice on successful PR merge

### DIFF
--- a/.github/workflows/CI main.yml
+++ b/.github/workflows/CI main.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build_and_push:
-    # if: github.event_name == 'push' || github.event.pull_request.merged
+    # if: github.event.pull_request.merged
     name: build and push Docker image to ghcr
     
     runs-on: ubuntu-latest

--- a/.github/workflows/CI main.yml
+++ b/.github/workflows/CI main.yml
@@ -3,9 +3,17 @@ name: CI main
 on:
   push:
     branches: "main"
-  pull_request:
-    types: closed
-    branches: "main"
+
+  # since a closed pull request results in a push, having both the 
+  # following code and the above code uncommented will cause 
+  # this workflow to run twice. only either the above code, on push 
+  # to main, or the below code, on closed PR to main, should be used
+  # (if using the below code, uncomment the conditional statement below)
+
+  # pull_request:
+  #   types: closed
+  #   branches: "main"
+
   workflow_dispatch:
 
 env:
@@ -14,7 +22,7 @@ env:
 
 jobs:
   build_and_push:
-    if: github.event_name == 'push' || github.event.pull_request.merged
+    # if: github.event_name == 'push' || github.event.pull_request.merged
     name: build and push Docker image to ghcr
     
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Resolves #30

---

Disables the 'on closed PR' workflow trigger in the main CI. This will prevent the main CI workflow from running twice when a PR is successfully merged into the main branch. The main CI workflow will still run on successful PR merge because every PR merge results in a push, which also triggers the main CI workflow.